### PR TITLE
docs: fix type description for DefaultLayout props in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,12 +194,12 @@ type RenderItem = (props: {
 
 | Prop | Type | Default | Description |
 | - | - | - | - |
-| `closeButtonCaption` | Object | 'Close (Esc)' | `.pswp__button--close` caption |
-| `shareButtonCaption` | Object | 'Share' | `.pswp__button--share` caption |
-| `toggleFullscreenButtonCaption` | Object | 'Toggle fullscreen' | `.pswp__button--fs` caption |
-| `zoomButtonCaption` | Object | 'Zoom in/out' | `.pswp__button--zoom` caption |
-| `prevButtonCaption` | Object | 'Previous (arrow left)' | `.pswp__button--arrow--left` caption |
-| `nextButtonCaption` | Object | 'Next (arrow right)' | `.pswp__button--arrow--right` caption |
+| `closeButtonCaption` | String | 'Close (Esc)' | `.pswp__button--close` caption |
+| `shareButtonCaption` | String | 'Share' | `.pswp__button--share` caption |
+| `toggleFullscreenButtonCaption` | String | 'Toggle fullscreen' | `.pswp__button--fs` caption |
+| `zoomButtonCaption` | String | 'Zoom in/out' | `.pswp__button--zoom` caption |
+| `prevButtonCaption` | String | 'Previous (arrow left)' | `.pswp__button--arrow--left` caption |
+| `nextButtonCaption` | String | 'Next (arrow right)' | `.pswp__button--arrow--right` caption |
 | `shareButton` | Boolean | `true` | Show `.pswp__button--share` |
 | `fullscreenButton` | Boolean | `true` | Show `.pswp__button--fs` |
 | `zoomButton` | Boolean | `true` | Show `.pswp__button--zoom` |


### PR DESCRIPTION
Fixes mistake in README

In README it's said, that caption is Object
<img width="884" alt="Снимок экрана 2021-11-22 в 18 24 05" src="https://user-images.githubusercontent.com/37641303/142827558-7c47eb11-fc4b-4f58-b156-c4c816bbdbe3.png">

While in code it's string
<img width="392" alt="Снимок экрана 2021-11-22 в 18 23 41" src="https://user-images.githubusercontent.com/37641303/142827589-7ece7ab6-03de-428d-a9af-524f3c7f2dcd.png">



