### PR TITLE
Docs improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,40 @@ const MyGallery = () => (
 
 [Example](https://github.com/dromru/react-photoswipe-gallery/blob/master/src/storybook/custom-content.stories.tsx)
 
+## Access to Photoswipe instance
+
+If you need to get access to Photoswipe instance (for example, to subscribe on [Photoswipe events](https://photoswipe.com/events/) or call some [Photoswipe method](https://photoswipe.com/methods/)),
+you can do it via `onOpen` and `onBeforeOpen` props of `Gallery` component.
+
+`onBeforeOpen` triggers before `PhotoSwipe.init()` call.
+
+`onOpen` triggers after `PhotoSwipe.init()` call.
+
+`onBeforeOpen` and `onOpen` will receive PhotoSwipe instance as the first argument.
+
+```javascript
+const onBeforeOpen = (pswpInstance) => {
+  pswpInstance.on('change', () => {
+    console.log('slide was changed')
+  })
+}
+
+const onOpen = (pswpInstance) => {
+  pswpInstance.currSlide.zoomTo(
+    1,
+    { x: 0, y: 0 },
+    2000,
+    false
+  )
+}
+
+const MyGallery = () => (
+  <Gallery onBeforeOpen={onBeforeOpen} onOpen={onOpen}>
+    {/*...*/}
+  </Gallery>
+)
+```
+
 ## Props
 
 ### Gallery

--- a/README.md
+++ b/README.md
@@ -272,7 +272,41 @@ The `useGallery` hook returns an object with some useful methods.
 | - | - | - |
 | `open` | (index: number) => void | This function allows programmatically open Photoswipe UI at `index`|
 
+`useGallery` hook gets context provided by `Gallery` component.
+So to use `useGallery` hook you need to store your galley content as separate component and then wrap it into `Gallery` component.
 
+```javascript
+const GalleryContent = () => {
+  const { open } = useGallery()
+    
+  useEffect(() => {
+      open(1) // you can open second slide by calling open(1) in useEffect
+  }, [open])
+    
+  return (
+    <div>
+      {/* or you can open second slide on button click */}
+      <button onClick={() => open(1)}>Open second slide</button>
+      <div>
+        <Item>...</Item>
+        <Item>...</Item>
+        <Item>...</Item>
+      </div>
+    </div>
+  )
+}
+
+const MyGallery = () => {
+  return (
+    {/* Gallery component provides context for useGallery hook used in GalleryContent */}
+    <Gallery>
+      <GalleryContent />
+    </Gallery>
+  )
+}
+```
+
+[Example](https://github.com/dromru/react-photoswipe-gallery/blob/master/src/storybook/playground.stories.tsx)
 
 ## Requirements
 


### PR DESCRIPTION
This PR adds to readme:
- example of `useGallery` hook usage
- section `Access to Photoswipe instance`

resolves:
- https://github.com/dromru/react-photoswipe-gallery/issues/871
- https://github.com/dromru/react-photoswipe-gallery/issues/852