### PR TITLE
Fix history updates during hash navigation

### DIFF
--- a/src/__tests__/hash-includes-navigation-query-params.test.ts
+++ b/src/__tests__/hash-includes-navigation-query-params.test.ts
@@ -1,0 +1,45 @@
+import hashIncludesNavigationQueryParams from '../helpers/hash-includes-navigation-query-params'
+
+describe('hashIncludesNavigationQueryParams helper', () => {
+  test('returns true if hash includes both query params: gid and pid', () => {
+    expect(hashIncludesNavigationQueryParams('gid=my-gallery&pid=123')).toBe(
+      true,
+    )
+    expect(
+      hashIncludesNavigationQueryParams('args=1&gid=my-gallery&pid=my-slide'),
+    ).toBe(true)
+    expect(
+      hashIncludesNavigationQueryParams('args=1&gid=321&pid=my-slide'),
+    ).toBe(true)
+    expect(hashIncludesNavigationQueryParams('gid=321&pid=my-slide')).toBe(true)
+    expect(hashIncludesNavigationQueryParams('pid=my-slide&gid=321')).toBe(true)
+    expect(
+      hashIncludesNavigationQueryParams(
+        'gid=gallery&args=value&a=1&pid=321&b=2',
+      ),
+    ).toBe(true)
+  })
+
+  test('returns false if hash includes both query params: gid and pid', () => {
+    expect(hashIncludesNavigationQueryParams('')).toBe(false)
+    expect(hashIncludesNavigationQueryParams('gid=my-gallery')).toBe(false)
+    expect(hashIncludesNavigationQueryParams('pid=123')).toBe(false)
+    expect(hashIncludesNavigationQueryParams('args=1&gid=321')).toBe(false)
+    expect(
+      hashIncludesNavigationQueryParams('args=value&a=1&gid=321&b=2'),
+    ).toBe(false)
+    expect(hashIncludesNavigationQueryParams('args=value&a=1&b=2')).toBe(false)
+    expect(hashIncludesNavigationQueryParams('args=value&pid=1&pid=2')).toBe(
+      false,
+    )
+    expect(hashIncludesNavigationQueryParams('args=value&pid=1&pid=2')).toBe(
+      false,
+    )
+    expect(hashIncludesNavigationQueryParams('args=value&gid=1&pid=')).toBe(
+      false,
+    )
+    expect(hashIncludesNavigationQueryParams('args=value&gid=&pid=2')).toBe(
+      false,
+    )
+  })
+})

--- a/src/helpers/hash-includes-navigation-query-params.ts
+++ b/src/helpers/hash-includes-navigation-query-params.ts
@@ -1,0 +1,8 @@
+import hashToObject from './hash-to-object'
+
+const hashIncludesNavigationQueryParams = (hash: string): boolean => {
+  const hashParts = hashToObject(hash)
+  return Boolean(hashParts.gid) && Boolean(hashParts.pid)
+}
+
+export default hashIncludesNavigationQueryParams


### PR DESCRIPTION
Fix update of history state on slide change.

Previously is was `history.pushState` on every slide change event, now it is `history.replaceState`.

Also add closing of gallery on `history.back()`(browser's back button).

Fix opening of previously closed gallery on `history.forward()`(browser's forward button).