### PR TITLE
Update photoswipe to v5.3.5

### DIFF
--- a/src/__tests__/get-initial-active-slide-index.test.ts
+++ b/src/__tests__/get-initial-active-slide-index.test.ts
@@ -1,0 +1,15 @@
+import getInitialActiveSlideIndex from '../helpers/get-initial-active-slide-index'
+
+describe('getInitialActiveSlideIndex helper', () => {
+  test('index is number, targetId is null', () => {
+    expect(getInitialActiveSlideIndex(10, null)).toBe(10)
+  })
+
+  test('index is null, targetId is defined', () => {
+    expect(getInitialActiveSlideIndex(null, '5')).toBe(4)
+  })
+
+  test('index is null, targetId is null', () => {
+    expect(getInitialActiveSlideIndex(null, null)).toBe(0)
+  })
+})

--- a/src/__tests__/object-to-hash.test.ts
+++ b/src/__tests__/object-to-hash.test.ts
@@ -1,6 +1,4 @@
-import objectToHash from '../helpers/object-to-hash'
-
-type InputObject = Record<string, string | number | undefined>
+import objectToHash, { InputObject } from '../helpers/object-to-hash'
 
 describe('objectToHash helper', () => {
   test('single key, without value', () => {

--- a/src/helpers/get-initial-active-slide-index.ts
+++ b/src/helpers/get-initial-active-slide-index.ts
@@ -1,0 +1,12 @@
+function getInitialActiveSlideIndex(
+  index: number | null,
+  targetId: string | null | undefined,
+): number {
+  if (index !== null) {
+    return index
+  }
+
+  return targetId ? parseInt(targetId, 10) - 1 : 0
+}
+
+export default getInitialActiveSlideIndex

--- a/src/helpers/object-to-hash.ts
+++ b/src/helpers/object-to-hash.ts
@@ -1,4 +1,6 @@
-function objectToHash(obj: Record<string, string | number>): string {
+export type InputObject = Record<string, string | number | undefined>
+
+function objectToHash(obj: InputObject): string {
   return Object.entries(obj)
     .map(([key, value]) => (value ? `${key}=${value}` : key))
     .join('&')

--- a/src/helpers/sort-nodes.ts
+++ b/src/helpers/sort-nodes.ts
@@ -1,7 +1,7 @@
 import { NoRefError } from '../no-ref-error'
 
-function sortNodes(a?: Element, b?: Element) {
-  if (!(a instanceof Element)) {
+function sortNodes(a: Element | null, b: Element | null) {
+  if (!(a instanceof Element) || !(b instanceof Element)) {
     throw new NoRefError()
   }
   if (a === b) return 0

--- a/src/item.ts
+++ b/src/item.ts
@@ -94,7 +94,7 @@ export interface ItemProps {
  * Should be a children of Gallery component
  */
 export const Item: FC<ItemProps> = ({ children, ...restProps }) => {
-  const ref: ItemRef = useRef()
+  const ref: ItemRef = useRef(null)
   const { remove, set, handleClick } = useContext(Context)
   const open = useCallback(
     (e: MouseEvent) => handleClick(ref, null, null, e),

--- a/src/storybook/helpers/items.ts
+++ b/src/storybook/helpers/items.ts
@@ -2,7 +2,7 @@ import { InternalItem } from '../../types'
 
 export const createItem = (
   index: number,
-  contentFn: false | ((i?: number) => JSX.Element | string) = false,
+  contentFn: false | ((i: number) => JSX.Element | string) = false,
 ): InternalItem => {
   if (typeof contentFn === 'function') {
     const content = contentFn(index)

--- a/src/storybook/rotate-slide-button.stories.tsx
+++ b/src/storybook/rotate-slide-button.stories.tsx
@@ -29,6 +29,10 @@ export const rotateSlideButton: Story = () => {
       },
       appendTo: 'bar',
       onClick: (e, el, pswpInstance) => {
+        if (!pswpInstance.currSlide?.content.element) {
+          return
+        }
+
         const item = pswpInstance.currSlide.content.element
 
         const prevRotateAngle = Number(item.dataset.rotateAngel) || 0
@@ -45,6 +49,10 @@ export const rotateSlideButton: Story = () => {
         // remove applied rotation on slide change
         // https://photoswipe.com/events/#slide-content-events
         pswpInstance.on('contentRemove', () => {
+          if (!pswpInstance.currSlide?.content.element) {
+            return
+          }
+
           const item = pswpInstance.currSlide.content.element
           item.style.transform = `${item.style.transform.replace(
             `rotate(-${item.dataset.rotateAngel}deg)`,

--- a/src/storybook/thumbnails-in-opened-photoswipe.stories.tsx
+++ b/src/storybook/thumbnails-in-opened-photoswipe.stories.tsx
@@ -53,11 +53,13 @@ export const thumbnailsInOpenedPhotoswipe: Story = () => {
               target.tagName === 'IMG'
                 ? target.parentElement
                 : (e.target as HTMLImageElement | HTMLDivElement)
-            pswpInstance.goTo(thumbnails.indexOf(thumbnailEl))
+            if (thumbnailEl) {
+              pswpInstance.goTo(thumbnails.indexOf(thumbnailEl))
+            }
           }
 
           const thumbnailImage = document.createElement('img')
-          thumbnailImage.setAttribute('src', slideData.msrc)
+          thumbnailImage.setAttribute('src', slideData.msrc || '')
           thumbnailImage.style.width = '100%'
           thumbnailImage.style.height = '100%'
           thumbnailImage.style.objectFit = 'cover'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import { MouseEvent } from 'react'
 import { ItemProps } from './item'
 
-export type ItemRef = React.MutableRefObject<HTMLElement>
+export type ItemRef = React.MutableRefObject<HTMLElement | null>
 
 export type InternalItem = Omit<ItemProps, 'children'>
 
@@ -14,5 +14,5 @@ export interface InternalAPI {
     itemIndex?: number | null,
     e?: MouseEvent | null,
   ) => void
-  open: (i?: number) => void
+  open: (i: number) => void
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,6 @@
     "jsx": "react",
     "declaration": true,
     "strict": true,
-    "strictNullChecks": false,
     "skipLibCheck": true,
     "sourceMap": true,
     "allowJs": false,


### PR DESCRIPTION
Improved types annotations were added in Photoswipe v.5.3.5.

In this PR we update photoswipe to v5.3.5 and remove type errors in react-photoswipe-gallery.