### PR TITLE
Change Item ref to callback ref

### DIFF
--- a/src/__tests__/index.test.tsx
+++ b/src/__tests__/index.test.tsx
@@ -222,7 +222,7 @@ const TestGallery: React.FC<{ items: InternalItem[] } & GalleryProps> = ({
 }) => (
   <Gallery {...rest}>
     {items.map(({ original, thumbnail, width, height, caption, id }) => (
-      <Item
+      <Item<HTMLImageElement>
         key={original}
         original={original}
         thumbnail={thumbnail}
@@ -236,7 +236,7 @@ const TestGallery: React.FC<{ items: InternalItem[] } & GalleryProps> = ({
             role="img"
             onClick={open}
             src={thumbnail}
-            ref={ref as React.MutableRefObject<HTMLImageElement>}
+            ref={ref}
             alt={caption}
           />
         )}
@@ -253,7 +253,7 @@ const ItemsWithHooks: React.FC<{ items: InternalItem[]; index: number }> = ({
   return (
     <>
       {items.map(({ original, thumbnail, width, height, caption, id }) => (
-        <Item
+        <Item<HTMLImageElement>
           key={original}
           original={original}
           thumbnail={thumbnail}
@@ -262,13 +262,7 @@ const ItemsWithHooks: React.FC<{ items: InternalItem[]; index: number }> = ({
           caption={caption}
           id={id}
         >
-          {({ ref }) => (
-            <img
-              role="img"
-              src={thumbnail}
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
-            />
-          )}
+          {({ ref }) => <img role="img" src={thumbnail} ref={ref} />}
         </Item>
       ))}
       <button type="button" onClick={() => open(index)} id="show">
@@ -292,7 +286,7 @@ const StatefulItem: React.FC<{ caption: string }> = (props) => {
   // eslint-disable-next-line react/destructuring-assignment
   const [caption, setCaption] = useState(props.caption)
   return (
-    <Item
+    <Item<HTMLImageElement>
       original="https://placekitten.com/1024/768?image=1"
       thumbnail="https://placekitten.com/160/120?image=1"
       width={1024}
@@ -305,7 +299,7 @@ const StatefulItem: React.FC<{ caption: string }> = (props) => {
             role="img"
             onClick={open}
             src="https://placekitten.com/160/120?image=1"
-            ref={ref as React.MutableRefObject<HTMLImageElement>}
+            ref={ref}
             alt={caption}
           />
           <button
@@ -323,7 +317,7 @@ const TestGalleryWithStatefulItem: React.FC = () => {
   return (
     <Gallery>
       <StatefulItem caption="First" />
-      <Item
+      <Item<HTMLImageElement>
         original="https://placekitten.com/1024/768?image=2"
         thumbnail="https://placekitten.com/160/120?image=2"
         width={1024}
@@ -335,7 +329,7 @@ const TestGalleryWithStatefulItem: React.FC = () => {
             role="img"
             onClick={open}
             src="https://placekitten.com/160/120?image=2"
-            ref={ref as React.MutableRefObject<HTMLImageElement>}
+            ref={ref}
             alt="Second"
           />
         )}
@@ -865,14 +859,8 @@ describe('gallery', () => {
 
     render(
       <Gallery>
-        <Item html="html string">
-          {({ ref, open }) => (
-            <span
-              role="link"
-              onClick={open}
-              ref={ref as React.MutableRefObject<HTMLSpanElement>}
-            />
-          )}
+        <Item<HTMLSpanElement> html="html string">
+          {({ ref, open }) => <span role="link" onClick={open} ref={ref} />}
         </Item>
       </Gallery>,
     )
@@ -893,23 +881,11 @@ describe('gallery', () => {
 
     render(
       <Gallery>
-        <Item content={reactElement}>
-          {({ ref, open }) => (
-            <span
-              role="link"
-              onClick={open}
-              ref={ref as React.MutableRefObject<HTMLSpanElement>}
-            />
-          )}
+        <Item<HTMLSpanElement> content={reactElement}>
+          {({ ref, open }) => <span role="link" onClick={open} ref={ref} />}
         </Item>
-        <Item html="foo">
-          {({ ref, open }) => (
-            <span
-              role="link"
-              onClick={open}
-              ref={ref as React.MutableRefObject<HTMLSpanElement>}
-            />
-          )}
+        <Item<HTMLSpanElement> html="foo">
+          {({ ref, open }) => <span role="link" onClick={open} ref={ref} />}
         </Item>
       </Gallery>,
     )

--- a/src/gallery.tsx
+++ b/src/gallery.tsx
@@ -1,5 +1,5 @@
 import PhotoSwipe from 'photoswipe'
-import type { SlideData, PhotoSwipeOptions, UIElementData } from 'photoswipe'
+import type { SlideData } from 'photoswipe'
 import React, {
   useRef,
   useCallback,
@@ -7,7 +7,6 @@ import React, {
   useMemo,
   useState,
   FC,
-  ReactNode,
   ReactPortal,
 } from 'react'
 import { createPortal } from 'react-dom'
@@ -21,7 +20,7 @@ import getBaseUrl from './helpers/get-base-url'
 import hashIncludesNavigationQueryParams from './helpers/hash-includes-navigation-query-params'
 import getInitialActiveSlideIndex from './helpers/get-initial-active-slide-index'
 import { Context } from './context'
-import { ItemRef, InternalItem, InternalAPI } from './types'
+import { ItemRef, InternalItem, InternalAPI, GalleryProps } from './types'
 import PhotoSwipeLightboxStub from './lightbox-stub'
 
 /**
@@ -30,76 +29,6 @@ import PhotoSwipeLightboxStub from './lightbox-stub'
  * (analog of window.pswp in 'photoswipe/lightbox')
  */
 let pswp: PhotoSwipe | null = null
-
-export interface GalleryProps {
-  children?: ReactNode
-
-  /**
-   * PhotoSwipe options
-   *
-   * https://photoswipe.com/options/
-   */
-  options?: PhotoSwipeOptions
-
-  /**
-   * Function for registering PhotoSwipe plugins
-   *
-   * You should pass `photoswipeLightbox` to each plugin constructor
-   */
-  plugins?: (photoswipeLightbox: PhotoSwipeLightboxStub) => void
-
-  /**
-   * Array of configuration objects for custom UI elements
-   *
-   * Use it for adding custom UI elements
-   *
-   * https://photoswipe.com/adding-ui-elements
-   */
-  uiElements?: UIElementData[]
-
-  /**
-   * Gallery ID, for hash navigation
-   */
-  id?: string | number
-
-  /**
-   * Triggers before PhotoSwipe.init() call
-   *
-   * Use it for accessing PhotoSwipe API
-   *
-   * https://photoswipe.com/events/
-   * https://photoswipe.com/filters/
-   * https://photoswipe.com/methods/
-   */
-  onBeforeOpen?: (photoswipe: PhotoSwipe) => void
-
-  /**
-   * Triggers after PhotoSwipe.init() call
-   *
-   * Use it for accessing PhotoSwipe API
-   *
-   * https://photoswipe.com/events/
-   * https://photoswipe.com/filters/
-   * https://photoswipe.com/methods/
-   */
-  onOpen?: (photoswipe: PhotoSwipe) => void
-
-  /**
-   * Enables built-in caption display
-   *
-   * Use the `caption` prop of the Item component to control caption text
-   *
-   * https://photoswipe.com/caption/
-   */
-  withCaption?: boolean
-
-  /**
-   * Adds UI control for downloading the original image of the current slide
-   *
-   * https://photoswipe.com/adding-ui-elements/#adding-download-button
-   */
-  withDownloadButton?: boolean
-}
 
 /**
  * Gallery component providing photoswipe context
@@ -167,6 +96,9 @@ export const Gallery: FC<GalleryProps> = ({
           src: original,
           srcset: originalSrcset,
           msrc: thumbnail,
+          // @ts-expect-error: right now sortNodes throws exception if any of ref.current in items is not an Element.
+          // Ideally, such exception should not be thrown from sorting function but check should be done before sorting
+          // TODO: extract exception from sortNodes, add typeguard that ref.current is actually an Element
           element: ref.current,
           thumbCropped: cropped,
           content,

--- a/src/helpers/sort-nodes.ts
+++ b/src/helpers/sort-nodes.ts
@@ -1,6 +1,6 @@
 import { NoRefError } from '../no-ref-error'
 
-function sortNodes(a: Element | undefined, b: Element | undefined) {
+function sortNodes(a: Element | null, b: Element | null) {
   if (!(a instanceof Element) || !(b instanceof Element)) {
     throw new NoRefError()
   }

--- a/src/storybook/basic.stories.tsx
+++ b/src/storybook/basic.stories.tsx
@@ -24,7 +24,7 @@ export const basic: Story = () => {
           gridGap: 12,
         }}
       >
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3894/15008518202_c265dfa55f_h.jpg"
           thumbnail="https://farm4.staticflickr.com/3894/15008518202_b016d7d289_m.jpg"
           width="1600"
@@ -35,12 +35,12 @@ export const basic: Story = () => {
             <img
               style={{ cursor: 'pointer' }}
               src="https://farm4.staticflickr.com/3894/15008518202_b016d7d289_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm6.staticflickr.com/5591/15008867125_b61960af01_h.jpg"
           thumbnail="https://farm6.staticflickr.com/5591/15008867125_68a8ed88cc_m.jpg"
           width="1600"
@@ -51,12 +51,12 @@ export const basic: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm6.staticflickr.com/5591/15008867125_68a8ed88cc_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_b.jpg"
           thumbnail="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_m.jpg"
           width="1600"
@@ -67,12 +67,12 @@ export const basic: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm6.staticflickr.com/5584/14985868676_b51baa4071_h.jpg"
           thumbnail="https://farm6.staticflickr.com/5584/14985868676_4b802b932a_m.jpg"
           width="1600"
@@ -83,12 +83,12 @@ export const basic: Story = () => {
             <img
               style={{ ...smallItemStyles, gridColumnStart: 2 }}
               src="https://farm6.staticflickr.com/5584/14985868676_4b802b932a_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3920/15008465772_d50c8f0531_h.jpg"
           thumbnail="https://farm4.staticflickr.com/3920/15008465772_383e697089_m.jpg"
           width="1600"
@@ -99,7 +99,7 @@ export const basic: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm4.staticflickr.com/3920/15008465772_383e697089_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}

--- a/src/storybook/cropped.stories.tsx
+++ b/src/storybook/cropped.stories.tsx
@@ -23,7 +23,7 @@ export const cropped: Story = () => {
           gridGap: 10,
         }}
       >
-        <Item
+        <Item<HTMLImageElement>
           cropped
           original="https://source.unsplash.com/IXP_xjMntlc/1920x2879"
           thumbnail="https://source.unsplash.com/IXP_xjMntlc/640x959"
@@ -34,12 +34,12 @@ export const cropped: Story = () => {
             <img
               style={smallItemStyles}
               src="https://source.unsplash.com/IXP_xjMntlc/640x959"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           cropped
           original="https://farm4.staticflickr.com/3894/15008518202_c265dfa55f_h.jpg"
           thumbnail="https://farm4.staticflickr.com/3894/15008518202_b016d7d289_m.jpg"
@@ -50,12 +50,12 @@ export const cropped: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm4.staticflickr.com/3894/15008518202_b016d7d289_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           cropped
           original="https://farm6.staticflickr.com/5591/15008867125_b61960af01_h.jpg"
           thumbnail="https://farm6.staticflickr.com/5591/15008867125_68a8ed88cc_m.jpg"
@@ -66,12 +66,12 @@ export const cropped: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm6.staticflickr.com/5591/15008867125_68a8ed88cc_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           cropped
           original="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_b.jpg"
           thumbnail="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_m.jpg"
@@ -82,12 +82,12 @@ export const cropped: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           cropped
           original="https://farm6.staticflickr.com/5584/14985868676_b51baa4071_h.jpg"
           thumbnail="https://farm6.staticflickr.com/5584/14985868676_4b802b932a_m.jpg"
@@ -98,12 +98,12 @@ export const cropped: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm6.staticflickr.com/5584/14985868676_4b802b932a_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           cropped
           original="https://farm4.staticflickr.com/3920/15008465772_d50c8f0531_h.jpg"
           thumbnail="https://farm4.staticflickr.com/3920/15008465772_383e697089_m.jpg"
@@ -114,7 +114,7 @@ export const cropped: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm4.staticflickr.com/3920/15008465772_383e697089_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}

--- a/src/storybook/custom-content.stories.tsx
+++ b/src/storybook/custom-content.stories.tsx
@@ -59,7 +59,7 @@ export const simpleHtml: Story = () => {
 
   return (
     <Gallery options={{ showHideOpacity: true }}>
-      <Item html={htmlString(1)}>
+      <Item<HTMLAnchorElement> html={htmlString(1)}>
         {({ ref, open }) => (
           <a
             href="#"
@@ -67,14 +67,14 @@ export const simpleHtml: Story = () => {
               e.preventDefault()
               open(e)
             }}
-            ref={ref as React.MutableRefObject<HTMLAnchorElement>}
+            ref={ref}
           >
             Open a slide with raw html content 1
           </a>
         )}
       </Item>
       <br />
-      <Item html={htmlString(2)}>
+      <Item<HTMLAnchorElement> html={htmlString(2)}>
         {({ ref, open }) => (
           <a
             href="#"
@@ -82,7 +82,7 @@ export const simpleHtml: Story = () => {
               e.preventDefault()
               open(e)
             }}
-            ref={ref as React.MutableRefObject<HTMLAnchorElement>}
+            ref={ref}
           >
             Open a slide with raw html content 2
           </a>
@@ -94,7 +94,9 @@ export const simpleHtml: Story = () => {
 
 export const reactElements: Story = () => (
   <Gallery options={{ showHideOpacity: true }}>
-    <Item content={<Content text="It's a React slide #1, nice!" />}>
+    <Item<HTMLAnchorElement>
+      content={<Content text="It's a React slide #1, nice!" />}
+    >
       {({ ref, open }) => (
         <a
           href="#"
@@ -102,14 +104,16 @@ export const reactElements: Story = () => (
             e.preventDefault()
             open(e)
           }}
-          ref={ref as React.MutableRefObject<HTMLAnchorElement>}
+          ref={ref}
         >
           Open a slide with React content 1
         </a>
       )}
     </Item>
     <br />
-    <Item content={<Content text="It's a React slide #2, nice!" />}>
+    <Item<HTMLAnchorElement>
+      content={<Content text="It's a React slide #2, nice!" />}
+    >
       {({ ref, open }) => (
         <a
           href="#"
@@ -117,7 +121,7 @@ export const reactElements: Story = () => (
             e.preventDefault()
             open(e)
           }}
-          ref={ref as React.MutableRefObject<HTMLAnchorElement>}
+          ref={ref}
         >
           Open a slide with React content 2
         </a>
@@ -163,7 +167,7 @@ const Map: React.FC<{ url: string }> = ({ url }) => {
 
 export const googleMaps: Story = () => (
   <Gallery options={{ showHideOpacity: true }}>
-    <Item content={<Map url={gmUrl1} />}>
+    <Item<HTMLAnchorElement> content={<Map url={gmUrl1} />}>
       {({ ref, open }) => (
         <a
           href="#"
@@ -171,14 +175,14 @@ export const googleMaps: Story = () => (
             e.preventDefault()
             open(e)
           }}
-          ref={ref as React.MutableRefObject<HTMLAnchorElement>}
+          ref={ref}
         >
           Open a map #1
         </a>
       )}
     </Item>
     <br />
-    <Item content={<Map url={gmUrl2} />}>
+    <Item<HTMLAnchorElement> content={<Map url={gmUrl2} />}>
       {({ ref, open }) => (
         <a
           href="#"
@@ -186,7 +190,7 @@ export const googleMaps: Story = () => (
             e.preventDefault()
             open(e)
           }}
-          ref={ref as React.MutableRefObject<HTMLAnchorElement>}
+          ref={ref}
         >
           Open a map #2
         </a>

--- a/src/storybook/hash-navigation.stories.tsx
+++ b/src/storybook/hash-navigation.stories.tsx
@@ -43,7 +43,7 @@ export const hashNavigation: Story = () => {
           gridGap: 12,
         }}
       >
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3894/15008518202_c265dfa55f_h.jpg"
           thumbnail="https://farm4.staticflickr.com/3894/15008518202_b016d7d289_m.jpg"
           width="1600"
@@ -56,12 +56,12 @@ export const hashNavigation: Story = () => {
             <img
               style={{ cursor: 'pointer' }}
               src="https://farm4.staticflickr.com/3894/15008518202_b016d7d289_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm6.staticflickr.com/5591/15008867125_b61960af01_h.jpg"
           thumbnail="https://farm6.staticflickr.com/5591/15008867125_68a8ed88cc_m.jpg"
           width="1600"
@@ -74,12 +74,12 @@ export const hashNavigation: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm6.staticflickr.com/5591/15008867125_68a8ed88cc_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_b.jpg"
           thumbnail="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_m.jpg"
           width="1600"
@@ -91,12 +91,12 @@ export const hashNavigation: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm6.staticflickr.com/5584/14985868676_b51baa4071_h.jpg"
           thumbnail="https://farm6.staticflickr.com/5584/14985868676_4b802b932a_m.jpg"
           width="1600"
@@ -107,12 +107,12 @@ export const hashNavigation: Story = () => {
             <img
               style={{ ...smallItemStyles, gridColumnStart: 2 }}
               src="https://farm6.staticflickr.com/5584/14985868676_4b802b932a_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3920/15008465772_d50c8f0531_h.jpg"
           thumbnail="https://farm4.staticflickr.com/3920/15008465772_383e697089_m.jpg"
           width="1600"
@@ -123,7 +123,7 @@ export const hashNavigation: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm4.staticflickr.com/3920/15008465772_383e697089_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}

--- a/src/storybook/playground.stories.tsx
+++ b/src/storybook/playground.stories.tsx
@@ -32,7 +32,7 @@ const ImageItem: FC<InternalItem> = ({
 }) => {
   const [fullCaption, setFullCaption] = useState(caption)
   return (
-    <Item
+    <Item<HTMLImageElement>
       original={original}
       thumbnail={thumbnail}
       width={width}
@@ -45,7 +45,7 @@ const ImageItem: FC<InternalItem> = ({
           <img
             onClick={open}
             src={thumbnail}
-            ref={ref as React.MutableRefObject<HTMLImageElement>}
+            ref={ref}
             style={{ display: 'block', cursor: 'pointer', marginBottom: 5 }}
           />
           <input

--- a/src/storybook/plugins.stories.tsx
+++ b/src/storybook/plugins.stories.tsx
@@ -40,7 +40,7 @@ export const plugins: Story = () => {
           gridGap: 12,
         }}
       >
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3894/15008518202_c265dfa55f_h.jpg"
           thumbnail="https://farm4.staticflickr.com/3894/15008518202_b016d7d289_m.jpg"
           width="1600"
@@ -51,12 +51,12 @@ export const plugins: Story = () => {
             <img
               style={{ cursor: 'pointer' }}
               src="https://farm4.staticflickr.com/3894/15008518202_b016d7d289_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm6.staticflickr.com/5591/15008867125_b61960af01_h.jpg"
           thumbnail="https://farm6.staticflickr.com/5591/15008867125_68a8ed88cc_m.jpg"
           width="1600"
@@ -67,12 +67,12 @@ export const plugins: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm6.staticflickr.com/5591/15008867125_68a8ed88cc_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_b.jpg"
           thumbnail="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_m.jpg"
           width="1600"
@@ -83,12 +83,12 @@ export const plugins: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm6.staticflickr.com/5584/14985868676_b51baa4071_h.jpg"
           thumbnail="https://farm6.staticflickr.com/5584/14985868676_4b802b932a_m.jpg"
           width="1600"
@@ -99,12 +99,12 @@ export const plugins: Story = () => {
             <img
               style={{ ...smallItemStyles, gridColumnStart: 2 }}
               src="https://farm6.staticflickr.com/5584/14985868676_4b802b932a_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3920/15008465772_d50c8f0531_h.jpg"
           thumbnail="https://farm4.staticflickr.com/3920/15008465772_383e697089_m.jpg"
           width="1600"
@@ -115,7 +115,7 @@ export const plugins: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm4.staticflickr.com/3920/15008465772_383e697089_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}

--- a/src/storybook/rotate-slide-button.stories.tsx
+++ b/src/storybook/rotate-slide-button.stories.tsx
@@ -74,7 +74,7 @@ export const rotateSlideButton: Story = () => {
           gridGap: 12,
         }}
       >
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3894/15008518202_c265dfa55f_h.jpg"
           thumbnail="https://farm4.staticflickr.com/3894/15008518202_b016d7d289_m.jpg"
           width="1600"
@@ -85,12 +85,12 @@ export const rotateSlideButton: Story = () => {
             <img
               style={{ cursor: 'pointer' }}
               src="https://farm4.staticflickr.com/3894/15008518202_b016d7d289_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm6.staticflickr.com/5591/15008867125_b61960af01_h.jpg"
           thumbnail="https://farm6.staticflickr.com/5591/15008867125_68a8ed88cc_m.jpg"
           width="1600"
@@ -101,12 +101,12 @@ export const rotateSlideButton: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm6.staticflickr.com/5591/15008867125_68a8ed88cc_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_b.jpg"
           thumbnail="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_m.jpg"
           width="1600"
@@ -117,12 +117,12 @@ export const rotateSlideButton: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm6.staticflickr.com/5584/14985868676_b51baa4071_h.jpg"
           thumbnail="https://farm6.staticflickr.com/5584/14985868676_4b802b932a_m.jpg"
           width="1600"
@@ -133,12 +133,12 @@ export const rotateSlideButton: Story = () => {
             <img
               style={{ ...smallItemStyles, gridColumnStart: 2 }}
               src="https://farm6.staticflickr.com/5584/14985868676_4b802b932a_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3920/15008465772_d50c8f0531_h.jpg"
           thumbnail="https://farm4.staticflickr.com/3920/15008465772_383e697089_m.jpg"
           width="1600"
@@ -149,7 +149,7 @@ export const rotateSlideButton: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm4.staticflickr.com/3920/15008465772_383e697089_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}

--- a/src/storybook/srcset.stories.tsx
+++ b/src/storybook/srcset.stories.tsx
@@ -24,7 +24,7 @@ export const srcset: Story = () => {
           gridGap: 12,
         }}
       >
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3894/15008518202_c265dfa55f_h.jpg"
           originalSrcset="https://farm4.staticflickr.com/3894/15008518202_c265dfa55f_h.jpg 1600w, https://farm4.staticflickr.com/3894/15008518202_b016d7d289_m.jpg 240w, https://farm4.staticflickr.com/3894/15008518202_c265dfa55f_h.jpg"
           thumbnail="https://farm4.staticflickr.com/3894/15008518202_b016d7d289_m.jpg"
@@ -35,12 +35,12 @@ export const srcset: Story = () => {
             <img
               style={{ cursor: 'pointer' }}
               src="https://farm4.staticflickr.com/3894/15008518202_b016d7d289_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm6.staticflickr.com/5591/15008867125_b61960af01_h.jpg"
           originalSrcset="https://farm6.staticflickr.com/5591/15008867125_b61960af01_h.jpg 1600w, https://farm6.staticflickr.com/5591/15008867125_68a8ed88cc_m.jpg 240w, https://farm6.staticflickr.com/5591/15008867125_b61960af01_h.jpg"
           thumbnail="https://farm6.staticflickr.com/5591/15008867125_68a8ed88cc_m.jpg"
@@ -51,12 +51,12 @@ export const srcset: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm6.staticflickr.com/5591/15008867125_68a8ed88cc_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_b.jpg"
           originalSrcset="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_b.jpg 1600w, https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_m.jpg 240w, https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_b.jpg"
           thumbnail="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_m.jpg"
@@ -67,12 +67,12 @@ export const srcset: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm6.staticflickr.com/5584/14985868676_b51baa4071_h.jpg"
           originalSrcset="https://farm6.staticflickr.com/5584/14985868676_b51baa4071_h.jpg 1600w, https://farm6.staticflickr.com/5584/14985868676_4b802b932a_m.jpg 240w, https://farm6.staticflickr.com/5584/14985868676_b51baa4071_h.jpg"
           thumbnail="https://farm6.staticflickr.com/5584/14985868676_4b802b932a_m.jpg"
@@ -83,12 +83,12 @@ export const srcset: Story = () => {
             <img
               style={{ ...smallItemStyles, gridColumnStart: 2 }}
               src="https://farm6.staticflickr.com/5584/14985868676_4b802b932a_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3920/15008465772_d50c8f0531_h.jpg"
           originalSrcset="https://farm4.staticflickr.com/3920/15008465772_d50c8f0531_h.jpg 1600w, https://farm4.staticflickr.com/3920/15008465772_383e697089_m.jpg 240w, https://farm4.staticflickr.com/3920/15008465772_d50c8f0531_h.jpg"
           thumbnail="https://farm4.staticflickr.com/3920/15008465772_383e697089_m.jpg"
@@ -99,7 +99,7 @@ export const srcset: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm4.staticflickr.com/3920/15008465772_383e697089_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}

--- a/src/storybook/thumbnails-in-opened-photoswipe.stories.tsx
+++ b/src/storybook/thumbnails-in-opened-photoswipe.stories.tsx
@@ -100,7 +100,7 @@ export const thumbnailsInOpenedPhotoswipe: Story = () => {
           gridGap: 12,
         }}
       >
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3894/15008518202_c265dfa55f_h.jpg"
           thumbnail="https://farm4.staticflickr.com/3894/15008518202_b016d7d289_m.jpg"
           width="1600"
@@ -111,12 +111,12 @@ export const thumbnailsInOpenedPhotoswipe: Story = () => {
             <img
               style={{ cursor: 'pointer' }}
               src="https://farm4.staticflickr.com/3894/15008518202_b016d7d289_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm6.staticflickr.com/5591/15008867125_b61960af01_h.jpg"
           thumbnail="https://farm6.staticflickr.com/5591/15008867125_68a8ed88cc_m.jpg"
           width="1600"
@@ -127,12 +127,12 @@ export const thumbnailsInOpenedPhotoswipe: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm6.staticflickr.com/5591/15008867125_68a8ed88cc_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_b.jpg"
           thumbnail="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_m.jpg"
           width="1600"
@@ -143,12 +143,12 @@ export const thumbnailsInOpenedPhotoswipe: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm6.staticflickr.com/5584/14985868676_b51baa4071_h.jpg"
           thumbnail="https://farm6.staticflickr.com/5584/14985868676_4b802b932a_m.jpg"
           width="1600"
@@ -159,12 +159,12 @@ export const thumbnailsInOpenedPhotoswipe: Story = () => {
             <img
               style={{ ...smallItemStyles, gridColumnStart: 2 }}
               src="https://farm6.staticflickr.com/5584/14985868676_4b802b932a_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3920/15008465772_d50c8f0531_h.jpg"
           thumbnail="https://farm4.staticflickr.com/3920/15008465772_383e697089_m.jpg"
           width="1600"
@@ -175,7 +175,7 @@ export const thumbnailsInOpenedPhotoswipe: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm4.staticflickr.com/3920/15008465772_383e697089_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}

--- a/src/storybook/with-caption.stories.tsx
+++ b/src/storybook/with-caption.stories.tsx
@@ -24,7 +24,7 @@ export const caption: Story = () => {
           gridGap: 12,
         }}
       >
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3894/15008518202_c265dfa55f_h.jpg"
           thumbnail="https://farm4.staticflickr.com/3894/15008518202_b016d7d289_m.jpg"
           width="1600"
@@ -36,12 +36,12 @@ export const caption: Story = () => {
             <img
               style={{ cursor: 'pointer' }}
               src="https://farm4.staticflickr.com/3894/15008518202_b016d7d289_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm6.staticflickr.com/5591/15008867125_b61960af01_h.jpg"
           thumbnail="https://farm6.staticflickr.com/5591/15008867125_68a8ed88cc_m.jpg"
           width="1600"
@@ -53,12 +53,12 @@ export const caption: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm6.staticflickr.com/5591/15008867125_68a8ed88cc_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_b.jpg"
           thumbnail="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_m.jpg"
           width="1600"
@@ -71,12 +71,12 @@ export const caption: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm6.staticflickr.com/5584/14985868676_b51baa4071_h.jpg"
           thumbnail="https://farm6.staticflickr.com/5584/14985868676_4b802b932a_m.jpg"
           width="1600"
@@ -88,12 +88,12 @@ export const caption: Story = () => {
             <img
               style={{ ...smallItemStyles, gridColumnStart: 2 }}
               src="https://farm6.staticflickr.com/5584/14985868676_4b802b932a_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3920/15008465772_d50c8f0531_h.jpg"
           thumbnail="https://farm4.staticflickr.com/3920/15008465772_383e697089_m.jpg"
           width="1600"
@@ -105,7 +105,7 @@ export const caption: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm4.staticflickr.com/3920/15008465772_383e697089_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}

--- a/src/storybook/with-download-button.stories.tsx
+++ b/src/storybook/with-download-button.stories.tsx
@@ -24,7 +24,7 @@ export const downloadButton: Story = () => {
           gridGap: 12,
         }}
       >
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3894/15008518202_c265dfa55f_h.jpg"
           thumbnail="https://farm4.staticflickr.com/3894/15008518202_b016d7d289_m.jpg"
           width="1600"
@@ -35,12 +35,12 @@ export const downloadButton: Story = () => {
             <img
               style={{ cursor: 'pointer' }}
               src="https://farm4.staticflickr.com/3894/15008518202_b016d7d289_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm6.staticflickr.com/5591/15008867125_b61960af01_h.jpg"
           thumbnail="https://farm6.staticflickr.com/5591/15008867125_68a8ed88cc_m.jpg"
           width="1600"
@@ -51,12 +51,12 @@ export const downloadButton: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm6.staticflickr.com/5591/15008867125_68a8ed88cc_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_b.jpg"
           thumbnail="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_m.jpg"
           width="1600"
@@ -67,12 +67,12 @@ export const downloadButton: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm4.staticflickr.com/3902/14985871946_86abb8c56f_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm6.staticflickr.com/5584/14985868676_b51baa4071_h.jpg"
           thumbnail="https://farm6.staticflickr.com/5584/14985868676_4b802b932a_m.jpg"
           width="1600"
@@ -83,12 +83,12 @@ export const downloadButton: Story = () => {
             <img
               style={{ ...smallItemStyles, gridColumnStart: 2 }}
               src="https://farm6.staticflickr.com/5584/14985868676_4b802b932a_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}
         </Item>
-        <Item
+        <Item<HTMLImageElement>
           original="https://farm4.staticflickr.com/3920/15008465772_d50c8f0531_h.jpg"
           thumbnail="https://farm4.staticflickr.com/3920/15008465772_383e697089_m.jpg"
           width="1600"
@@ -99,7 +99,7 @@ export const downloadButton: Story = () => {
             <img
               style={smallItemStyles}
               src="https://farm4.staticflickr.com/3920/15008465772_383e697089_m.jpg"
-              ref={ref as React.MutableRefObject<HTMLImageElement>}
+              ref={ref}
               onClick={open}
             />
           )}

--- a/src/storybook/without-images.stories.tsx
+++ b/src/storybook/without-images.stories.tsx
@@ -74,9 +74,9 @@ export const withoutImages: Story = ({ content }) => {
       </div>
       <ul>
         {links.map((props) => (
-          <Item {...props} key={props.original || props.caption}>
+          <Item<HTMLLIElement> {...props} key={props.original || props.caption}>
             {({ ref, open }) => (
-              <li ref={ref as React.MutableRefObject<HTMLLIElement>}>
+              <li ref={ref}>
                 <a
                   href="#"
                   onClick={(e) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,73 @@
-import { MouseEvent } from 'react'
-import { ItemProps } from './item'
+import { MouseEvent, MutableRefObject, ReactNode } from 'react'
+import PhotoSwipe, { PhotoSwipeOptions, UIElementData } from 'photoswipe'
+import PhotoSwipeLightboxStub from './lightbox-stub'
 
-export type ItemRef = React.MutableRefObject<HTMLElement>
+/**
+ * At Gallery level we can freely assume that ref is HTMLElement since we don't use any of html attributes.
+ * At Item level we can either set ref type like <Item<HTMLImageElement>> to ensure typing or simply omit it since
+ * elements like HTMLImageElement extends HTMLElement.
+ */
+export type ItemRef<NodeType extends HTMLElement = HTMLElement> =
+  MutableRefObject<NodeType | null>
 
-export type InternalItem = Omit<ItemProps, 'children'>
+export interface InternalItem {
+  /**
+   * Url of original image
+   */
+  original?: string
 
+  /**
+   * Srcset of original image
+   */
+  originalSrcset?: string
+
+  /**
+   * Url of thumbnail
+   */
+  thumbnail?: string
+
+  /**
+   * Width of original image
+   */
+  width?: string | number
+
+  /**
+   * Height of original image
+   */
+  height?: string | number
+
+  /**
+   * Alternate text for original image
+   */
+  alt?: string
+
+  /**
+   * Text for caption
+   */
+  caption?: string
+
+  /**
+   * Custom slide content
+   */
+  content?: JSX.Element
+
+  /**
+   * Custom slide content (raw html)
+   *
+   * TODO: deprecate, use `content` instead
+   */
+  html?: string
+
+  /**
+   * Item ID, for hash navigation
+   */
+  id?: string | number
+
+  /**
+   * Thumbnail is cropped
+   */
+  cropped?: boolean
+}
 export interface InternalAPI {
   remove: (ref: ItemRef) => void
   set: (ref: ItemRef, data: InternalItem) => void
@@ -15,4 +78,74 @@ export interface InternalAPI {
     e?: MouseEvent | null,
   ) => void
   open: (i: number) => void
+}
+
+export interface GalleryProps {
+  children?: ReactNode
+
+  /**
+   * PhotoSwipe options
+   *
+   * https://photoswipe.com/options/
+   */
+  options?: PhotoSwipeOptions
+
+  /**
+   * Function for registering PhotoSwipe plugins
+   *
+   * You should pass `photoswipeLightbox` to each plugin constructor
+   */
+  plugins?: (photoswipeLightbox: PhotoSwipeLightboxStub) => void
+
+  /**
+   * Array of configuration objects for custom UI elements
+   *
+   * Use it for adding custom UI elements
+   *
+   * https://photoswipe.com/adding-ui-elements
+   */
+  uiElements?: UIElementData[]
+
+  /**
+   * Gallery ID, for hash navigation
+   */
+  id?: string | number
+
+  /**
+   * Triggers before PhotoSwipe.init() call
+   *
+   * Use it for accessing PhotoSwipe API
+   *
+   * https://photoswipe.com/events/
+   * https://photoswipe.com/filters/
+   * https://photoswipe.com/methods/
+   */
+  onBeforeOpen?: (photoswipe: PhotoSwipe) => void
+
+  /**
+   * Triggers after PhotoSwipe.init() call
+   *
+   * Use it for accessing PhotoSwipe API
+   *
+   * https://photoswipe.com/events/
+   * https://photoswipe.com/filters/
+   * https://photoswipe.com/methods/
+   */
+  onOpen?: (photoswipe: PhotoSwipe) => void
+
+  /**
+   * Enables built-in caption display
+   *
+   * Use the `caption` prop of the Item component to control caption text
+   *
+   * https://photoswipe.com/caption/
+   */
+  withCaption?: boolean
+
+  /**
+   * Adds UI control for downloading the original image of the current slide
+   *
+   * https://photoswipe.com/adding-ui-elements/#adding-download-button
+   */
+  withDownloadButton?: boolean
 }


### PR DESCRIPTION
RIght now there is necessity to manually cast ref type from `Item`, for example code
```
<Item>
  {({ ref }) => (
    <img ref={ref} />
  )}
</Item>
```
throws type error
```
Type 'ItemRef' is not assignable to type 'LegacyRef<HTMLImageElement> | undefined'.
  Type 'MutableRefObject<HTMLElement>' is not assignable to type 'RefObject<HTMLImageElement>'.
    Types of property 'current' are incompatible.
```

For typescript users the only option is to manyally cast ref to `React.MutableRefObject<HTMLImageElement>`.
I decided to try to fix it.

First, there is a type error in `ItemRef`. For now it is specified as `React.MutableRefObject<HTMLElement>`, but ref value also can be `undefined` if `ref` from `Item` was not attached. I changed type to 
```
type ItemRef<NodeType extends HTMLElement = HTMLElement> =
  MutableRefObject<NodeType | null>
```
so now
1.  we know that ref can be null (changed undefined to null) if not attached
2. it is generic type to allow properly typings

Second, I changed `ref` from `Item` from usual `Ref` to `ref callback`, which allows better typings. This change makes casting unnecessary. After all for end typescript users there are two option:

1. remove castings like `ref={ref as React.MutableRefObject<HTMLImageElement>}`, `ref={ref}` will just work
2. for better ref typing users can manually set ref type on Item:
```
<Item<HTMLImageElement>>
  {({ ref }) => (
    <img ref={ref} />
  )}
</Item>
```