### PR TITLE
fix: change useEffect to useLayoutEffect in Item component

### DIFF
--- a/src/item.ts
+++ b/src/item.ts
@@ -2,7 +2,7 @@ import {
   useRef,
   useCallback,
   useContext,
-  useEffect,
+  useLayoutEffect,
   FC,
   MouseEvent,
 } from 'react'
@@ -101,7 +101,7 @@ export const Item: FC<ItemProps> = ({ children, ...restProps }) => {
     [],
   )
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     set(ref, restProps)
     return () => remove(ref)
   }, Object.values(restProps))


### PR DESCRIPTION
After upgrading to react 18 i started to see rare `NoRefError` errors.

To reproduce it i had to click as fast as i can on element with `open` attached. I should start clicking before hydration finished, so the problem occur right after hydration. I assumed that since useEffect is kind of async there is small window between render and `useEffect` calling `set` for given `ref`

It seems that changing `useEffect` to `useLayoutEffect` fixed problem for me, at least i could not reproduce it with `useLayoutEffect`.

 After testing this fix with forked version i see no errors in sentry from production app