### PR TITLE
refactor: remove prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "@testing-library/react": "14.3.1",
     "@testing-library/user-event": "14.6.1",
     "@types/jest": "29.5.14",
-    "@types/prop-types": "15.7.15",
     "@types/react": "18.2.78",
     "@types/react-dom": "18.2.25",
     "@types/testing-library__dom": "7.5.0",
@@ -98,7 +97,6 @@
     "photoswipe-dynamic-caption-plugin": "dimsemenov/photoswipe-dynamic-caption-plugin",
     "pinst": "3.0.0",
     "prettier": "2.8.8",
-    "prop-types": "15.8.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "rimraf": "5.0.10",
@@ -113,7 +111,6 @@
   },
   "peerDependencies": {
     "photoswipe": ">= 5.2.2",
-    "prop-types": ">= 15.7.0",
     "react": ">= 16.8.0"
   },
   "resolutions": {

--- a/src/gallery.tsx
+++ b/src/gallery.tsx
@@ -9,7 +9,6 @@ import React, {
   ReactPortal,
 } from 'react'
 import { createPortal } from 'react-dom'
-import PropTypes from 'prop-types'
 import objectToHash from './helpers/object-to-hash'
 import hashToObject from './helpers/hash-to-object'
 import getHashWithoutGidAndPid from './helpers/get-hash-without-gid-and-pid'
@@ -438,15 +437,3 @@ export const Gallery: FC<GalleryProps> = ({
   )
 }
 
-Gallery.propTypes = {
-  children: PropTypes.any,
-  options: PropTypes.object,
-  plugins: PropTypes.func,
-  uiElements: PropTypes.array,
-  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  onBeforeOpen: PropTypes.func,
-  onOpen: PropTypes.func,
-  withCaption: PropTypes.bool,
-  withDownloadButton: PropTypes.bool,
-  dataSource: PropTypes.array,
-}

--- a/src/item.ts
+++ b/src/item.ts
@@ -1,5 +1,4 @@
 import { useRef, useEffect, useMemo, useCallback } from 'react'
-import PropTypes from 'prop-types'
 import { ChildrenFnProps, ItemProps } from './types'
 import { useApiContext } from './hooks'
 import { NoRefError } from './no-ref-error'
@@ -54,18 +53,3 @@ export const Item = <NodeType extends HTMLElement>({
   return children(childrenFnProps)
 }
 
-Item.propTypes = {
-  children: PropTypes.func.isRequired,
-  original: PropTypes.string,
-  originalSrcset: PropTypes.string,
-  thumbnail: PropTypes.string,
-  width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  alt: PropTypes.string,
-  caption: PropTypes.string,
-  content: PropTypes.element,
-  html: PropTypes.string,
-  id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-  cropped: PropTypes.bool,
-  sourceId: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5076,13 +5076,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/prop-types@npm:15.7.15":
-  version: 15.7.15
-  resolution: "@types/prop-types@npm:15.7.15"
-  checksum: 10/31aa2f59b28f24da6fb4f1d70807dae2aedfce090ec63eaf9ea01727a9533ef6eaf017de5bff99fbccad7d1c9e644f52c6c2ba30869465dd22b1a7221c29f356
-  languageName: node
-  linkType: hard
-
 "@types/qs@npm:*, @types/qs@npm:^6.9.5":
   version: 6.9.10
   resolution: "@types/qs@npm:6.9.10"
@@ -14928,7 +14921,7 @@ photoswipe-dynamic-caption-plugin@dimsemenov/photoswipe-dynamic-caption-plugin:
   languageName: node
   linkType: hard
 
-"prop-types@npm:15.8.1, prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -15235,7 +15228,6 @@ photoswipe-dynamic-caption-plugin@dimsemenov/photoswipe-dynamic-caption-plugin:
     "@testing-library/react": "npm:14.3.1"
     "@testing-library/user-event": "npm:14.6.1"
     "@types/jest": "npm:29.5.14"
-    "@types/prop-types": "npm:15.7.15"
     "@types/react": "npm:18.2.78"
     "@types/react-dom": "npm:18.2.25"
     "@types/testing-library__dom": "npm:7.5.0"
@@ -15265,7 +15257,6 @@ photoswipe-dynamic-caption-plugin@dimsemenov/photoswipe-dynamic-caption-plugin:
     photoswipe-dynamic-caption-plugin: dimsemenov/photoswipe-dynamic-caption-plugin
     pinst: "npm:3.0.0"
     prettier: "npm:2.8.8"
-    prop-types: "npm:15.8.1"
     react: "npm:18.2.0"
     react-dom: "npm:18.2.0"
     rimraf: "npm:5.0.10"
@@ -15279,7 +15270,6 @@ photoswipe-dynamic-caption-plugin@dimsemenov/photoswipe-dynamic-caption-plugin:
     webpack: "npm:5.91.0"
   peerDependencies:
     photoswipe: ">= 5.2.2"
-    prop-types: ">= 15.7.0"
     react: ">= 16.8.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary

Remove `prop-types` runtime validation from the library.

The library is written in TypeScript and already has comprehensive type definitions in `types.ts` (`GalleryProps`, `ItemProps`, etc.). The `PropTypes` declarations were a redundant, weaker parallel layer — e.g. `PropTypes.object` vs the precise `PhotoSwipeOptions` TypeScript type.

## Changes

- Remove `PropTypes` imports and `.propTypes` assignments from `src/gallery.tsx` and `src/item.ts`
- Remove `prop-types` from `peerDependencies`
- Remove `prop-types` and `@types/prop-types` from `devDependencies`

## Notes

Consumers no longer need to install `prop-types`. Type safety is fully provided by TypeScript. Plain-JS consumers lose runtime prop warnings, but the library remains fully functional — in line with the direction the broader React ecosystem has been moving (React 19 dropped built-in `propTypes` support).

Additionally, the [`prop-types`](https://github.com/facebook/prop-types) package itself has been archived by Facebook and is no longer maintained, making it an even stronger case for removal.