### PR TITLE
fix(hash-to-object): add URI decoding and preserve equals signs in values

### DIFF
--- a/src/__tests__/hash-to-object.test.ts
+++ b/src/__tests__/hash-to-object.test.ts
@@ -1,12 +1,12 @@
 import hashToObject from '../helpers/hash-to-object'
 
-type ExpectedObject = Record<string, string | undefined>
+type ExpectedObject = Record<string, string>
 
 describe('hashToObject helper', () => {
   test('single key, without value', () => {
     const hash = 'my-block'
     const expectedObject: ExpectedObject = {
-      'my-block': undefined,
+      'my-block': '',
     }
     expect(hashToObject(hash)).toEqual(expectedObject)
   })
@@ -40,9 +40,36 @@ describe('hashToObject helper', () => {
   test('complex', () => {
     const hash = 'my-block&gid=my-gallery&pid=second-slide'
     const expectedObject: ExpectedObject = {
-      'my-block': undefined,
+      'my-block': '',
       gid: 'my-gallery',
       pid: 'second-slide',
+    }
+    expect(hashToObject(hash)).toEqual(expectedObject)
+  })
+
+  test('should decode URI-encoded keys and values', () => {
+    const hash = 'gid=my%2Fgallery&pid=photo%2F1'
+    const expectedObject: ExpectedObject = {
+      gid: 'my/gallery',
+      pid: 'photo/1',
+    }
+    expect(hashToObject(hash)).toEqual(expectedObject)
+  })
+
+  test('should decode encoded special characters', () => {
+    const hash = 'gid=my%20gallery&pid=slide%231'
+    const expectedObject: ExpectedObject = {
+      gid: 'my gallery',
+      pid: 'slide#1',
+    }
+    expect(hashToObject(hash)).toEqual(expectedObject)
+  })
+
+  test('should handle value containing equals sign', () => {
+    const hash = 'gid=my-gallery&data=key%3Dvalue'
+    const expectedObject: ExpectedObject = {
+      gid: 'my-gallery',
+      data: 'key=value',
     }
     expect(hashToObject(hash)).toEqual(expectedObject)
   })

--- a/src/helpers/hash-to-object.ts
+++ b/src/helpers/hash-to-object.ts
@@ -1,8 +1,10 @@
 function hashToObject(hash: string): Record<string, string> {
   return hash.split('&').reduce((acc, keyValue) => {
-    const [key, value] = keyValue.split('=')
+    const [key, ...rest] = keyValue.split('=')
     if (key) {
-      acc[key] = value
+      const decodedKey = decodeURIComponent(key)
+      const value = rest.length > 0 ? rest.join('=') : undefined
+      acc[decodedKey] = value !== undefined ? decodeURIComponent(value) : ''
     }
     return acc
   }, {} as Record<string, string>)


### PR DESCRIPTION
## Summary

### Motivation

The `hashToObject` helper parses URL hash strings (e.g., `gid=my-gallery&pid=2`) into key-value objects. However, it had two issues:

1. **No URI decoding** — Encoded characters like `%20` (space) or `%23` (`#`) were stored as-is, causing mismatches when comparing hash values containing special or non-ASCII characters.
2. **Values with `=` were truncated** — `split('=')` split on every `=`, so a value like `key%3Dvalue` (decoded: `key=value`) would lose everything after the first `=`.

In addition, the return type `Record<string, string>` doesn't match the actual runtime behaviour: keys without values (e.g., `my-block` in `#my-block&gid=1`) returned `undefined` instead of a `string`. 
This has been unified to return an empty string `''`.

### What I have done

- Applied `decodeURIComponent` to both keys and values in `hashToObject`.
- Changed `split('=')` to destructure with rest (`[key, ...rest]`) and rejoin with `rest.join('=')` to preserve `=` characters within values.
- Unified the no-value case to return `''` instead of `undefined`, aligning the runtime behaviour with the `Record<string, string>` return type.
- Updated existing tests to reflect the `undefined` → `''` changing.

### Add Testing Types

- `should decode URI-encoded keys and values` — verifies encoded characters (`%2F`) are decoded correctly
- `should decode encoded special characters` — verifies `%20` → space, `%23` → `#`
- `should handle value containing equals sign` — verifies `key%3Dvalue` is decoded to `key=value`

### Test Results

```bash
 PASS  src/__tests__/hash-to-object.test.ts
  hashToObject helper
    ✓ single key, without value (2 ms)
    ✓ single key, with value
    ✓ two key and value pairs v1 (1 ms)
    ✓ two key and value pairs v2
    ✓ complex (1 ms)
    ✓ should decode URI-encoded keys and values
    ✓ should decode encoded special characters (1 ms)
    ✓ should handle value containing equals sign

-------------------|---------|----------|---------|---------|-------------------
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------------|---------|----------|---------|---------|-------------------
All files          |     100 |      100 |     100 |     100 |                   
 hash-to-object.ts |     100 |      100 |     100 |     100 |                   
-------------------|---------|----------|---------|---------|-------------------
Test Suites: 1 passed, 1 total
Tests:       8 passed, 8 total
Snapshots:   0 total
Time:        1.445 s
Ran all test suites matching /src\/__tests__\/hash-to-object.test.ts/i.
```